### PR TITLE
Added correct handling of NON-RAID option

### DIFF
--- a/idrac_2.2rc4
+++ b/idrac_2.2rc4
@@ -336,7 +336,7 @@ def config_verify():  # check if configurations are properly set
             print 'file %s not found!' % conf['mib']
             sys.exit(1)
     # set default state alert if user forgot to set
-    if conf['state_ok'] is None: conf['state_ok'] = '0|ok|online|on|spunup|full|ready|enabled|presence'
+    if conf['state_ok'] is None: conf['state_ok'] = '0|ok|online|on|spunup|full|ready|enabled|presence|NONRAID'
     if conf['state_warn'] is None: conf['state_warn'] = '$ALL$'
     if conf['state_crit'] is None: conf['state_crit'] = 'critical|nonRecoverable|fail'
     # verify if state alert is overlapped


### PR DESCRIPTION
without this quick fix, NON RAID disk are considered WARNING!
--
DISK
--PDisk 1 (0) 111.79 GB: ONLINE, PowerStat: ON, HotSpare: no [INTEL, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0
--PDisk 2 (1) 111.79 GB: ONLINE, PowerStat: ON, HotSpare: no [INTEL, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0
--PDisk 3 (0:1:0) 1788.5 GB: NONRAID, PowerStat: SPUNUP, HotSpare: no [TOSHIBA, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0
--PDisk 4 (0:1:1) 1788.5 GB: NONRAID, PowerStat: SPUNUP, HotSpare: no [TOSHIBA, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0
--PDisk 5 (0:1:2) 1788.5 GB: NONRAID, PowerStat: SPUNUP, HotSpare: no [TOSHIBA, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0
--PDisk 6 (0:1:3) 1788.5 GB: NONRAID, PowerStat: SPUNUP, HotSpare: no [TOSHIBA, SSD, S/N: XXXXXXXXXXXXXXXX] isFailing: 0