### PR TITLE
fix: switch for non-iterable values conf['state_*'] to on-the-fly splitting

### DIFF
--- a/check_idrac
+++ b/check_idrac
@@ -383,20 +383,14 @@ def config_verify():  # check if configurations are properly set
         conf['state_crit'] = 'critical|nonRecoverable|fail'
 
     # verify if state alert is overlapped
-    conf['state_ok'] = conf['state_ok'].split('|')
-    conf['state_warn'] = conf['state_warn'].split('|')
-    conf['state_crit'] = conf['state_crit'].split('|')
-    for w in conf['state_warn']:
-        if w in conf['state_ok'] or w in conf['state_crit']:
+    for w in conf['state_warn'].split('|'):
+        if w in conf['state_ok'].split('|') or w in conf['state_crit'].split('|'):
             print('state thresholds overlapped!')
             sys.exit(1)
-    for c in conf['state_crit']:
-        if c in conf['state_ok']:
+    for c in conf['state_crit'].split('|'):
+        if c in conf['state_ok'].split('|'):
             print('state thresholds overlapped!')
             sys.exit(1)
-    conf['state_ok'] = '|'.join(conf['state_ok'])
-    conf['state_warn'] = '|'.join(conf['state_warn'])
-    conf['state_crit'] = '|'.join(conf['state_crit'])
 
 
 class PARSER:


### PR DESCRIPTION
`pylint -E check_idrac` reports:

```
check_idrac:389:13: E1133: Non-iterable value conf['state_warn'] is used in an iterating context (not-an-iterable)
check_idrac:390:16: E1135: Value 'conf['state_ok']' doesn't support membership test (unsupported-membership-test)
check_idrac:390:41: E1135: Value 'conf['state_crit']' doesn't support membership test (unsupported-membership-test)
check_idrac:393:13: E1133: Non-iterable value conf['state_crit'] is used in an iterating context (not-an-iterable)
check_idrac:394:16: E1135: Value 'conf['state_ok']' doesn't support membership test (unsupported-membership-test)
```