### PR TITLE
fix: make values conf['hardware'] and 'conf['*_thresholds']' subscriptable

### DIFF
--- a/check_idrac
+++ b/check_idrac
@@ -28,19 +28,19 @@ conf = {'snmp_version': None,
         'state_ok': None,
         'state_warn': None,
         'state_crit': None,
-        'hardware': None,
+        'hardware': [],
         'alert': True,
         'mib': None,
         'file': None,
         'perf': False,
         'debug': False,
-        'fan_thresholds': None,
-        'voltage_thresholds': None,
-        'current_thresholds': None,
-        'watt_thresholds': None,
-        'sensor_thresholds': None,
-        'consumption_thresholds': None,
-        'vdisk_thresholds': None,
+        'fan_thresholds': [],
+        'voltage_thresholds': [],
+        'current_thresholds': [],
+        'watt_thresholds': [],
+        'sensor_thresholds': [],
+        'consumption_thresholds': [],
+        'vdisk_thresholds': [],
         'mem_modules': None,
         'host': None}
 
@@ -55,13 +55,13 @@ conf_file = {'snmp_version': None,
              'state_ok': None,
              'state_warn': None,
              'state_crit': None,
-             'fan_thresholds': None,
-             'voltage_thresholds': None,
-             'current_thresholds': None,
-             'watt_thresholds': None,
-             'sensor_thresholds': None,
-             'consumption_thresholds': None,
-             'vdisk_thresholds': None,
+             'fan_thresholds': [],
+             'voltage_thresholds': [],
+             'current_thresholds': [],
+             'watt_thresholds': [],
+             'sensor_thresholds': [],
+             'consumption_thresholds': [],
+             'vdisk_thresholds': [],
              'host_ipaddress': None}
 
 all_hardware = {
@@ -309,7 +309,8 @@ def config_reader():
 def config_verify():  # check if configurations are properly set
     # verify hardware input
     if conf['hardware']:
-        conf['hardware'] = conf['hardware'].split('#')
+        if isinstance(conf['hardware'], str):
+            conf['hardware'] = conf['hardware'].split('#')
         try:
             conf['hardware'][1] = int(conf['hardware'][1])
         except IndexError:


### PR DESCRIPTION
`pylint -E check_idrac` reports:
```
check_idrac:312:27: E1101: Instance of 'list' has no 'split' member (no-member)
check_idrac:314:12: E1137: "conf['hardware']" does not support item assignment (unsupported-assignment-operation)
check_idrac:314:38: E1136: Value 'conf['hardware']' is unsubscriptable (unsubscriptable-object)
check_idrac:404:37: E1136: Value 'conf['hardware']' is unsubscriptable (unsubscriptable-object)
check_idrac:405:21: E1136: Value 'conf['hardware']' is unsubscriptable (unsubscriptable-object)
check_idrac:549:27: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:550:69: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:553:27: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:554:69: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:557:27: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:558:69: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:562:27: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:563:69: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:571:31: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:572:75: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:575:31: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:576:75: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:579:31: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:580:75: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:584:31: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:585:75: E1136: Value 'conf['voltage_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:592:31: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:593:75: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:596:31: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:597:75: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:600:31: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:601:75: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:605:31: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:606:75: E1136: Value 'conf['current_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:613:31: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:614:75: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:617:31: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:618:75: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:621:31: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:622:75: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:626:31: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:627:75: E1136: Value 'conf['watt_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:632:27: E1136: Value 'conf['consumption_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:633:71: E1136: Value 'conf['consumption_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:636:27: E1136: Value 'conf['consumption_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:637:71: E1136: Value 'conf['consumption_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:644:27: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:645:71: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:648:27: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:649:71: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:652:27: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:653:71: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:657:27: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:658:71: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:663:27: E1136: Value 'conf['vdisk_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:664:69: E1136: Value 'conf['vdisk_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:667:27: E1136: Value 'conf['vdisk_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:668:69: E1136: Value 'conf['vdisk_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:853:48: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:853:75: E1136: Value 'conf['fan_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:871:66: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:872:35: E1136: Value 'conf['sensor_thresholds']' is unsubscriptable (unsubscriptable-object)
check_idrac:1063:15: E1136: Value 'conf['hardware']' is unsubscriptable (unsubscriptable-object)
check_idrac:1069:11: E1136: Value 'conf['hardware']' is unsubscriptable (unsubscriptable-object)
```